### PR TITLE
WIP: hdl_server now compiles on ps2dev:latest

### DIFF
--- a/svr/ipconfig.c
+++ b/svr/ipconfig.c
@@ -2,7 +2,10 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdlib.h>
-#include <fileio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "ipconfig.h"
 
@@ -71,11 +74,11 @@ int ParseConfig(const char *path, char *ip_address, char *subnet_mask, char *gat
     char *FileBuffer, *line, *field;
     unsigned int i;
 
-    if ((fd = fioOpen(path, O_RDONLY)) >= 0) {
-        size = fioLseek(fd, 0, SEEK_END);
-        fioLseek(fd, 0, SEEK_SET);
+    if ((fd = open(path, O_RDONLY)) >= 0) {
+        size = lseek(fd, 0, SEEK_END);
+        lseek(fd, 0, SEEK_SET);
         if ((FileBuffer = malloc(size)) != NULL) {
-            if (fioRead(fd, FileBuffer, size) == size) {
+            if (read(fd, FileBuffer, size) == size) {
                 if ((line = strtok(FileBuffer, "\r\n")) != NULL) {
                     result = EINVAL;
                     do {
@@ -108,7 +111,7 @@ int ParseConfig(const char *path, char *ip_address, char *subnet_mask, char *gat
         } else
             result = ENOMEM;
 
-        fioClose(fd);
+        close(fd);
     } else
         result = fd;
 

--- a/svr/pktdrv/Makefile
+++ b/svr/pktdrv/Makefile
@@ -2,7 +2,8 @@ IOP_BIN = pktdrv.irx
 IOP_OBJS = main.o arp.o eth.o icmp.o ip.o nic.o udp.o svr.o ipconfig.o imports.o
 
 IOP_INCS += -I$(PS2SDK)/iop/include
-IOP_CFLAGS += -Wall -fno-builtin -D_IOP
+#IOP_CFLAGS += -Wall -fno-builtin -D_IOP
+IOP_CFLAGS += -Wall -fno-builtin -D_IOP -mgpopt -G8192
 IOP_LDFLAGS += -s
 
 all: $(IOP_BIN)
@@ -11,4 +12,6 @@ clean:
 	rm -f $(IOP_OBJS) $(IOP_BIN)
 
 include $(PS2SDK)/Defs.make
-include Rules.make
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.iopglobal
+#include Rules.make

--- a/svr/pktdrv/imports.lst
+++ b/svr/pktdrv/imports.lst
@@ -25,6 +25,6 @@ sysclib_IMPORTS_end
 netman_IMPORTS_start
 I_NetManRegisterNetworkStack
 I_NetManUnregisterNetworkStack
-I_NetManNetIFSendPacket
+I_NetManNetIFXmit
 I_NetManIoctl
 netman_IMPORTS_end

--- a/svr/pktdrv/main.c
+++ b/svr/pktdrv/main.c
@@ -17,9 +17,17 @@
 
 IRX_ID("PKTDRV_stack", 0x00, 0x80);
 
+struct NetManPacketBuffer{
+	void *handle;
+	void *payload;
+	u32 length;
+};
+
 static unsigned char FrameBuffer[1600];
 static struct NetManPacketBuffer RxPbuf;
 static unsigned int PacketAvailable = 1;
+
+
 
 static void LinkStateUp(void)
 {

--- a/svr/pktdrv/nic.c
+++ b/svr/pktdrv/nic.c
@@ -43,7 +43,9 @@ nic_get_state(void *buf)
 int nic_send(const void *pPacket, int size)
 {
     // return(SMAPSendPacket(pPacket, size)!=0?1:0);
-    return (NetManNetIFSendPacket(pPacket, size) != 0 ? 1 : 0);
+    //return (NetManNetIFSendPacket(pPacket, size) != 0 ? 1 : 0);
+	NetManNetIFXmit();
+	return 0;
 }
 
 int nic_send_wait(const void *pPacket, int size)


### PR DESCRIPTION
For people interested to help, not to be committed yet.
Feel free to comment here.

It seems a lot of work to port to latest LWIP.
I wonder if we should discard it and use https://github.com/ps2homebrew/Open-PS2-Loader/tree/master/modules/hdd/hdldsvr
in hdl-dump client.

EDIT:  Join https://github.com/ps2homebrew/Open-PS2-Loader/issues/410 about hdldsvr discussion.