### PR TITLE
apa_dump_header: discard usage of osal_xxx function

### DIFF
--- a/apa.h
+++ b/apa.h
@@ -150,7 +150,7 @@ int apa_initialize_ex(hio_t *hio, const char *file_name);
 int apa_dump_mbr(const dict_t *config,
                  const char *device, const char *file_name);
 
-int apa_dump_header(hio_t *hio, u_int32_t starting_partition_sector);
+int apa_dump_header(const char *path, u_int32_t starting_partition_sector);
 
 C_END
 

--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -1287,7 +1287,7 @@ dump_header(const dict_t *config,
 
             if (result == RET_OK) {
                 u_int32_t start_sector = get_u32(&toc->slice[slice_index].parts[partition_index].header.start);
-                result = apa_dump_header(hio, start_sector);
+                result = apa_dump_header(device, start_sector);
             }
 
             apa_toc_free(toc), toc = NULL;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

i think there is weird bug in osal_create_file() , btw to sum up my point of view on OSAL (OS abstraction layer), this is no more needed and we should avoid to use OSAL and prefer rewrite on stdio. Same for HIO (HDL abstraction) that was first targeting driver like udpnet and so, not the idea was bad, but seems obsolete and not follow anyway. Since i rewrite a mkpart like, i try to code this full stdio to look where i go before change anything else.

