### PR TITLE
add CMD_MKPART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ MXE_TARGETS ?= i686-w64-mingw32.static
 # configuration end
 ###############################################################################
 
-CFLAGS = -Wall -ansi -pedantic -Wno-long-long
+CFLAGS = -Wall -std=c11 -pedantic -Wno-long-long
 
 LDFLAGS =
 
@@ -181,6 +181,9 @@ format:
 
 format-check:
 	@! find . -type f -a \( -iname \*.h -o -iname \*.c \) | xargs clang-format -style=file -output-replacements-xml | grep "<replacement "
+
+clean-header:
+	rm -f system.cnf icon.sys list.ico del.ico boot.kelf boot.kirx HEADER_*
 
 # rules below
 rsrc.o: rsrc.rc

--- a/config.h
+++ b/config.h
@@ -104,6 +104,7 @@ static const compat_flags_t COMPAT_FLAGS_INVALID = (compat_flags_t)-1;
 #define INCLUDE_DIAG_CMD
 #define INCLUDE_MODIFY_CMD
 #define INCLUDE_COPY_HDD_CMD
+#define INCLUDE_MKPART_CMD
 #undef INCLUDE_HIDE_CMD /*Hide function is malfunction*/
 
 /* option names and values for the config file */


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

I try to find a way to make ps2 linux from maximus32 easy and error prone install thanks to hdl_dump #49

few lines on the current process, next we need inject_raw cmd. But we have to find solution to avoid editing fstab and loader configuration.

```
https://www.psx-place.com/threads/ps2linux-version-3-8-a-new-update-from-maximus32.11382/
sudo kpartx -a ps2linux3.8_v0.1.img
```
vmlinux-v3.8.gz seems to wait for GPT table, enumerate /dev/sda , i can't boot from it.
vmlinux-v2.6.35.gz 2 enumerate from APA part name, so no need to edit file in fs and can be used with hdl_dump.
Only PS2_LINUX_ID "__linux." prefixed partition are  visible from Linux , no content check, but seems to show PP one. Perhaps it would be better to check the partition type instead of name, to allow usage of PP partition, starting by "PP." ie "PP.Blackrhino" (so rely on other element, like in partition superblock, UUID, LABEL ...).
```
hdl_dump mkpart /dev/sdb __linux.1 ext2 1920M
hdl_dump mkpart /dev/sdb __linux.2 swap 124M
hdl_dump toc /dev/sdb --dm | sudo dmsetup create --concise
mkfs.ext2 -I 128 /dev/disk/by-id/dm-name-sdb-__linux.1
mkswap  /dev/disk/by-id/dm-name-sdb-__linux.2
losetup -f  __linux.1
mkdir -p orig dest
sudo mount /dev/loop1 orig
sudo mount /dev/disk/by-id/dm-name-sdb-__linux.1 dest
sudo rsync -aAXv orig/ dest/
sudo vim dest/etc/fstab
sudo umount orig/ dest/
losetup -d /dev/loop1
dmsetup remove_all

```
