### PR TITLE
make `modify_header` accept game name

### DIFF
--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -1255,7 +1255,6 @@ modify_header(const dict_t *config,
             u_int32_t partition_index = 0;
             result = apa_find_partition(toc, partname, &slice_index,
                                         &partition_index);
-            
             if (result == RET_NOT_FOUND) { /* assume it is `game_name' and not a partition name */
                 char partition_id[PS2_PART_IDMAX + 1];
                 result = hdl_lookup_partition_ex(hio, partname, partition_id);

--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -1255,7 +1255,15 @@ modify_header(const dict_t *config,
             u_int32_t partition_index = 0;
             result = apa_find_partition(toc, partname, &slice_index,
                                         &partition_index);
-
+            
+            if (result == RET_NOT_FOUND) { /* assume it is `game_name' and not a partition name */
+                char partition_id[PS2_PART_IDMAX + 1];
+                result = hdl_lookup_partition_ex(hio, partname, partition_id);
+                if (result == RET_OK)
+                    result = apa_find_partition(toc, partition_id,
+                                                &slice_index, &partition_index);
+            }
+            
             if (result == RET_OK) {
                 u_int32_t start_sector = get_u32(&toc->slice[slice_index].parts[partition_index].header.start);
                 result = hdd_inject_header(hio, toc, slice_index, start_sector);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Allow `modify_header` to be used with game names like other commands (such as `modify` do) as an alternative to partition name