### PR TITLE
avoid trailing whitespace on partition name

### DIFF
--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -133,9 +133,9 @@ show_apa_slice(const apa_slice_t *slice)
                 slice->parts[i].modified != 0 ? '*' : ':',
                 (unsigned long)(get_u32(&part->length) / 2048));
         if (get_u32(&part->main) == 0)
-            fprintf(stdout, "%4x [%-*s]\n",
+            fprintf(stdout, "%4x [%s]\n",
                     (unsigned int)get_u16(&part->type),
-                    PS2_PART_IDMAX, part->id);
+                    part->id);
         else
             fprintf(stdout, "      part # %2lu in %06lx00\n",
                     (unsigned long)(get_u32(&part->number)),
@@ -165,14 +165,14 @@ show_apa_slice2(const apa_slice_t *slice)
             u_int32_t tot_len = get_u32(&part->length);
             for (j = 0; j < count; ++j)
                 tot_len += get_u32(&part->subs[j].length);
-            fprintf(stdout, "0x%04x %06lx00%c%c %2lu %5luMB %-*s\n",
+            fprintf(stdout, "0x%04x %06lx00%c%c %2lu %5luMB %s\n",
                     (unsigned int)get_u16(&part->type),
                     (unsigned long)get_u32(&part->start) >> 8,
                     slice->parts[i].existing != 0 ? '.' : '*',
                     slice->parts[i].modified != 0 ? '*' : ':',
                     (unsigned long)count + 1, /* main partition counts, too */
                     (unsigned long)tot_len / 2048,
-                    PS2_PART_IDMAX, part->id);
+                    part->id);
         }
     }
 


### PR DESCRIPTION

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

there is no data after partition name on `toc`, making the fprintf token to fill with whitespace till reaching 32 bytes useles

This only makes it Impossible for aumated scripts/ programs to pull the real partition name, since they can't make up the difference between real partition name whitespace and formatting whitespace.

I know that latest HDL-Dump does not allow whitespace into partition name anymore.

But consumers won't format the HDD again just because we changed partition name logic, (also, a lot of fools still use outdated tools like winhiip)