### PR TITLE
make isofs `system.cnf` parser accept `cdrom1:\\`

### DIFF
--- a/isofs.c
+++ b/isofs.c
@@ -237,7 +237,7 @@ parse_config_cnf(const char *contents,
             p += 5;
             while (*p == ' ' || *p == '\t' || *p == '=')
                 ++p;
-            if ((memcmp(p, "cdrom0:\\", 8) == 0) || (memcmp(p, "cdrom1:\\", 8) == 0)) { //Some crappy game mods use 'cdrom1:\\' instead, not sure why, but a considerable ammount of silly users don't like seing their game mods marked as invalid and they switch back to winhiip
+            if ((memcmp(p, "cdrom0:\\", 8) == 0) || (memcmp(p, "cdrom1:\\", 8) == 0)) {/*cdrom1 is used by some game mods*/
                 p += 8;
                 while (*p != ';')
                     *signature++ = *p++;

--- a/isofs.c
+++ b/isofs.c
@@ -237,7 +237,7 @@ parse_config_cnf(const char *contents,
             p += 5;
             while (*p == ' ' || *p == '\t' || *p == '=')
                 ++p;
-            if (memcmp(p, "cdrom0:\\", 8) == 0) {
+            if ((memcmp(p, "cdrom0:\\", 8) == 0) || (memcmp(p, "cdrom1:\\", 8) == 0)) { //Some crappy game mods use 'cdrom1:\\' instead, not sure why, but a considerable ammount of silly users don't like seing their game mods marked as invalid and they switch back to winhiip
                 p += 8;
                 while (*p != ';')
                     *signature++ = *p++;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Some crappy game mods use `cdrom1:\\` instead, not sure why, but a considerable ammount of silly users don't like seing their game mods marked as invalid and they switch back to winhiip