### PR TITLE
disable formatting macros on windows

### DIFF
--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -56,9 +56,15 @@
 #include "dict.h"
 #include "net_io.h"
 
+#if defined(_BUILD_WIN32)
+#define UNBOLD ""
+#define BOLD ""
+#define WARNING_SIGN ""
+#else
 #define UNBOLD       "\033[0m"
 #define BOLD         "\033[1m"
 #define WARNING_SIGN "/\033[4m!\033[0m\\"
+#endif
 
 /* command names */
 #define CMD_QUERY "query"


### PR DESCRIPTION
only windows 10/11 is supposed to support these scape sequences

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
