### PR TITLE
Fixed comparison bug

### DIFF
--- a/hdl_dump.c
+++ b/hdl_dump.c
@@ -1085,7 +1085,7 @@ inject(const dict_t *config,
             memmove(game.name, name, sizeof(game.name) - 1);
             game.name[sizeof(game.name) - 1] = '\0';
             game.layer_break = 0;
-            if (strcmp(&input[sizeof(input) - 4], ".zso") == 0) {
+            if (strcmp(&input[strlen(input) - 4], ".zso") != 0) {
                 result = isofs_get_ps2_cdvd_info(iin, &info);
                 if (result == RET_OK)
                     if (info.layer_pvd != 0)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Fixed issue where layer_break for dual layer DVDs was not being set, as well as the startup_elf when checking if an input file a ZSO.

This was causing all dual layer games not to work, and blank startup ELFs unless specified.